### PR TITLE
祝日の管理の追加

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2417,7 +2417,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9ba19973a58daf4db6f352eda73dc0e289493cd29fb2632eb172085b6521acd"
 
 [[package]]
-name = "wbs_api"
+name = "wbs_back"
 version = "0.1.0"
 dependencies = [
  "actix-cors",

--- a/migrations/2021-06-28-031459_create_holidays/down.sql
+++ b/migrations/2021-06-28-031459_create_holidays/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE holidays;

--- a/migrations/2021-06-28-031459_create_holidays/up.sql
+++ b/migrations/2021-06-28-031459_create_holidays/up.sql
@@ -1,0 +1,7 @@
+CREATE TABLE holidays (
+  id SERIAL PRIMARY KEY NOT NULL,
+  holiday_name    VARCHAR(255)                 NOT NULL,
+  target_at timestamp with time zone NOT NULL,
+  created_at timestamp with time zone NOT NULL default CURRENT_TIMESTAMP,
+  updated_at timestamp with time zone NOT NULL default CURRENT_TIMESTAMP
+);

--- a/src/db/models.rs
+++ b/src/db/models.rs
@@ -4,3 +4,4 @@ pub mod project_with_task_duration_view;
 pub mod task;
 pub mod user;
 pub mod memo;
+pub mod holiday;

--- a/src/db/models/holiday.rs
+++ b/src/db/models/holiday.rs
@@ -1,0 +1,26 @@
+use crate::schema::holidays;
+use chrono::NaiveDateTime;
+
+#[derive(PartialEq, Debug, Queryable, Associations, Clone, Identifiable)]
+// #[belongs_to(parent = "AssocProject", foreign_key = "project_id")]
+pub struct Holiday {
+    pub id: i32,
+    pub holiday_name: String,
+    pub target_at: NaiveDateTime,
+    pub created_at: NaiveDateTime,
+    pub updated_at: NaiveDateTime,
+}
+
+#[derive(Insertable)]
+#[table_name = "holidays"]
+pub struct HolidayNewForm<'a> {
+    pub holiday_name: &'a str,
+    pub target_at: NaiveDateTime,
+}
+
+#[derive(AsChangeset)]
+#[table_name = "holidays"]
+pub struct HolidayUpdateForm<'a> {
+    pub holiday_name: Option<&'a str>,
+    pub target_at: Option<NaiveDateTime>,
+}

--- a/src/db/repositories.rs
+++ b/src/db/repositories.rs
@@ -3,3 +3,4 @@ pub mod project_repository;
 pub mod task_repository;
 pub mod user_repository;
 pub mod memo_repository;
+pub mod holiday_repository;

--- a/src/db/repositories/holiday_repository.rs
+++ b/src/db/repositories/holiday_repository.rs
@@ -3,6 +3,7 @@ use crate::db::{
     models::holiday::{Holiday},
     models::holiday::{HolidayNewForm},
 };
+use chrono::{NaiveDate};
 use crate::graphql::schema::holiday::{NewHoliday, UpdateHoliday};
 use crate::graphql::schema::Context;
 use diesel::result::Error;
@@ -19,6 +20,16 @@ impl HolidayRepository {
         let conn = &context.pool.get().unwrap();
         // 構造体をばらしたtupleでもロードは可能
         holidays.load::<Holiday>(conn)
+    }
+
+    pub fn target_holidays(context: &Context, from: &str, to: &str) -> Result<Vec<Holiday>, Box<dyn std::error::Error>> {
+        use crate::schema::holidays::dsl::*;
+        let conn = &context.pool.get().unwrap();
+        // 構造体をばらしたtupleでもロードは可能
+        let from_date_time = NaiveDate::parse_from_str(&from, "%Y-%m-%d" )?.and_hms(00, 00, 00);
+        let to_date_time = NaiveDate::parse_from_str(&to, "%Y-%m-%d")?.and_hms(23, 59, 59);
+        let select_query = holidays.filter(target_at.between(from_date_time, to_date_time));
+        Ok(select_query.get_results::<Holiday>(conn)?)
     }
 
     pub fn insert_holiday(

--- a/src/db/repositories/holiday_repository.rs
+++ b/src/db/repositories/holiday_repository.rs
@@ -1,0 +1,20 @@
+use self::diesel::prelude::*;
+use crate::db::{
+    models::holiday::{Holiday},
+};
+use crate::graphql::schema::Context;
+use diesel::result::Error;
+
+extern crate diesel;
+
+pub struct HolidayRepository {}
+
+impl HolidayRepository {
+
+    pub fn all_holidays(context: &Context) -> Result<Vec<Holiday>, Error> {
+        use crate::schema::holydays::dsl::*;
+        let conn = &context.pool.get().unwrap();
+        // 構造体をばらしたtupleでもロードは可能
+        holidays.load::<Holiday>(conn)
+    }
+}

--- a/src/db/repositories/holiday_repository.rs
+++ b/src/db/repositories/holiday_repository.rs
@@ -1,9 +1,12 @@
 use self::diesel::prelude::*;
 use crate::db::{
     models::holiday::{Holiday},
+    models::holiday::{HolidayNewForm},
 };
+use crate::graphql::schema::holiday::{NewHoliday, UpdateHoliday};
 use crate::graphql::schema::Context;
 use diesel::result::Error;
+use std::convert::TryInto;
 
 extern crate diesel;
 
@@ -12,9 +15,38 @@ pub struct HolidayRepository {}
 impl HolidayRepository {
 
     pub fn all_holidays(context: &Context) -> Result<Vec<Holiday>, Error> {
-        use crate::schema::holydays::dsl::*;
+        use crate::schema::holidays::dsl::*;
         let conn = &context.pool.get().unwrap();
         // 構造体をばらしたtupleでもロードは可能
         holidays.load::<Holiday>(conn)
+    }
+
+    pub fn insert_holiday(
+        context: &Context,
+        new_holiday: NewHoliday,
+    ) -> Result<Holiday, Box<dyn std::error::Error>> {
+        use crate::schema::holidays::dsl::*;
+        use diesel::dsl::insert_into;
+        let conn = &context.pool.get().unwrap();
+        // PhotoFormのメンバは参照値なので参照値でintoかつライフタイムに注意
+        let holiday_form: HolidayNewForm = (&new_holiday).try_into()?;
+        let rows_inserted = insert_into(holidays)
+            .values(&holiday_form)
+            .get_result(conn)?;
+        Ok(rows_inserted)
+    }
+
+    pub fn delete_holiday(
+        context: &Context,
+        holiday_pkey: i32,
+    ) -> Result<Vec<Holiday>, Box<dyn std::error::Error>> {
+        use crate::schema::holidays::dsl::*;
+        use diesel::dsl::delete;
+        let conn = &context.pool.get().unwrap();
+        // PhotoFormのメンバは参照値なので参照値でintoかつライフタイムに注意
+        let rows_deleted = delete(holidays.filter(id.eq(holiday_pkey)))
+            .execute(conn)
+            .and_then(|_| holidays.load::<Holiday>(conn))?;
+        Ok(rows_deleted)
     }
 }

--- a/src/graphql/resolver.rs
+++ b/src/graphql/resolver.rs
@@ -66,6 +66,17 @@ impl Query {
             .map_err(Into::into);
         tasks
     }
+    /// プロジェクトすべてを取得するクエリ
+    fn all_holidays(&self, context: &Context) -> FieldResult<Vec<Holiday>> {
+        // and_thenでResultを別種のResultに変換
+        // ここではinto_iterでイテレータを取得し、mapで値一つ一つに対するintoを呼び出した値
+        // 最後のcollectはイテレータをVecに戻しているだけ
+        // Errorの場合はmap_errに入るのでintoで適当な値に変換
+        let holidays = HolidayRepository::all_holidays(context)
+            .and_then(|holidays| Ok(holidays.into_iter().map(|h| h.into()).collect()))
+            .map_err(Into::into);
+        holidays
+    }
 }
 
 #[juniper::graphql_object(Context = Context)]
@@ -179,8 +190,13 @@ impl Mutation {
         Ok(ret.into_iter().map(Into::into).collect())
     }
 
-    async fn create_holiday(&self, context: &Context, new_holiday: NewHoliday) -> Result<Vec<Holiday>, FieldError> {
-        let ret = HolidayRepository::insert_memo(context, new_holiday)?;
+    async fn create_holiday(&self, context: &Context, new_holiday: NewHoliday) -> Result<Holiday, FieldError> {
+        let ret = HolidayRepository::insert_holiday(context, new_holiday)?;
+        Ok(ret.into())
+    }
+
+    async fn delete_holiday(&self, context: &Context, id: i32) -> Result<Vec<Holiday>, FieldError> {
+        let ret = HolidayRepository::delete_holiday(context, id)?;
         Ok(ret.into_iter().map(Into::into).collect())
     }
 }

--- a/src/graphql/resolver.rs
+++ b/src/graphql/resolver.rs
@@ -3,11 +3,13 @@ use crate::db::repositories::project_repository::ProjectRepository;
 use crate::db::repositories::task_repository::TaskRepository;
 use crate::db::repositories::user_repository::UserRepository;
 use crate::db::repositories::memo_repository::MemoRepository;
+use crate::db::repositories::holiday_repository::HolidayRepository;
 use crate::graphql::schema::milestone::{Milestone, NewMilestone, UpdateMilestone};
 use crate::graphql::schema::project::{NewProject, Project, UpdateProject};
 use crate::graphql::schema::task::{NewTask, Task, UpdateTask};
 use crate::graphql::schema::user::{NewUser, UpdateUser, User};
 use crate::graphql::schema::memo::{NewMemo, UpdateMemo, Memo};
+use crate::graphql::schema::holiday::{NewHoliday, Holiday};
 use crate::graphql::schema::{Context, Mutation, Query};
 use diesel::result::Error;
 use juniper::{FieldError, FieldResult};
@@ -174,6 +176,11 @@ impl Mutation {
 
     async fn delete_memo(&self, context: &Context, id: i32) -> Result<Vec<Memo>, FieldError> {
         let ret = MemoRepository::delete_memo(context, id)?;
+        Ok(ret.into_iter().map(Into::into).collect())
+    }
+
+    async fn create_holiday(&self, context: &Context, new_holiday: NewHoliday) -> Result<Vec<Holiday>, FieldError> {
+        let ret = HolidayRepository::insert_memo(context, new_holiday)?;
         Ok(ret.into_iter().map(Into::into).collect())
     }
 }

--- a/src/graphql/schema.rs
+++ b/src/graphql/schema.rs
@@ -7,6 +7,7 @@ pub mod project;
 pub mod task;
 pub mod user;
 pub mod memo;
+pub mod holiday;
 
 pub struct Context {
     pub pool: DataPgPool,

--- a/src/graphql/schema/holiday.rs
+++ b/src/graphql/schema/holiday.rs
@@ -1,0 +1,85 @@
+use crate::db::models::*;
+use crate::graphql::schema::Context;
+use chrono::{NaiveDate, ParseError};
+use juniper::ID;
+use std::convert::TryFrom;
+
+pub struct Holiday {
+    id: i32,
+    holiday_name: String,
+    target_at: String,
+}
+
+#[derive(juniper::GraphQLInputObject)]
+#[graphql(description = "A Holiday create")]
+pub struct NewHoliday {
+    holiday_name: String,
+    target_at: String,
+}
+
+#[derive(juniper::GraphQLInputObject)]
+#[graphql(description = "A Holiday update")]
+pub struct UpdateHoliday {
+    holiday_name: Option<String>,
+    target_at: Option<String>,
+}
+
+#[juniper::graphql_object(Context = Context)]
+#[graphql(description = "A Holiday returns struct")]
+impl Holiday {
+    fn id(&self) -> ID {
+        ID::new(self.id.to_string())
+    }
+
+    fn holiday_name(&self) -> String {
+        self.holiday_name.clone()
+    }
+
+    fn target_at(&self) -> String {
+        self.target_at.clone()
+    }
+
+}
+
+
+// GraphQLのMemoをdieselのMemoに変換するFromトレイト実装
+impl From<holiday::Holiday> for Holiday {
+    fn from(holiday: holiday::Holiday) -> Self {
+        Self {
+            id: holiday.id,
+            holiday_name: holiday.holiday_name,
+            target_at: holiday.target_at.format("%Y-%m-%d").to_string(),
+        }
+    }
+}
+
+/// GraphQLの構造体NewMemoをdieselの構造体MemoNewFormに変換するFromトレイト実装
+impl<'a> TryFrom<&'a NewHoliday> for holiday::HolidayNewForm<'a> {
+    type Error = ParseError;
+    fn try_from(new_holiday: &'a NewHoliday) -> Result<Self, Self::Error> {
+
+        let target =
+            NaiveDate::parse_from_str(&new_holiday.target_at, "%Y-%m-%d")?.and_hms(00, 00, 00);
+        Ok(Self {
+            holiday_name: &new_holiday.holiday_name,
+            target_at: target
+        })
+    }
+}
+
+/// GraphQLの構造体UpdateMemoをdieselの構造体MemoUpdateFormに変換するFromトレイト実装
+impl<'a> TryFrom<&'a UpdateHoliday> for holiday::HolidayUpdateForm<'a> {
+    type Error = ParseError;
+
+    fn try_from(update_holiday: &'a UpdateHoliday) -> Result<Self, Self::Error> {
+
+        let target = match &update_holiday.target_at {
+            Some(target) => Some(NaiveDate::parse_from_str(&target, "%Y-%m-%d")?.and_hms(00, 00, 00)),
+            None => None,
+        };
+        Ok(Self {
+            holiday_name: update_holiday.holiday_name.as_ref().map(AsRef::as_ref),
+            target_at: target
+        })
+    }
+}

--- a/src/graphql/schema/project.rs
+++ b/src/graphql/schema/project.rs
@@ -1,8 +1,10 @@
 use crate::db::models::project_with_task_duration_view::ProjectWithTaskDurationView;
 use crate::db::models::*;
 use crate::db::repositories::task_repository::TaskRepository;
+use crate::db::repositories::holiday_repository::HolidayRepository;
 use crate::graphql::schema::milestone::Milestone;
 use crate::graphql::schema::task::Task;
+use crate::graphql::schema::holiday::Holiday;
 use crate::graphql::schema::Context;
 use chrono::{Local, NaiveDate, ParseError};
 use core::cmp;
@@ -71,6 +73,13 @@ impl Project {
             .into_iter()
             .map(|m| m.into())
             .collect())
+    }
+
+    async fn holidays(&self, context: &Context) -> FieldResult<Vec<Holiday>> {
+        let holidays = HolidayRepository::target_holidays(context, &self.started_at, &self.ended_at)
+            .and_then(|holidays| Ok(holidays.into_iter().map(|h| h.into()).collect()))
+            .map_err(Into::into);
+        holidays
     }
 }
 

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -1,4 +1,14 @@
 table! {
+    holidays (id) {
+        id -> Int4,
+        holiday_name -> Varchar,
+        target_at -> Timestamptz,
+        created_at -> Timestamptz,
+        updated_at -> Timestamptz,
+    }
+}
+
+table! {
     memos (id) {
         id -> Int4,
         task_id -> Int4,
@@ -65,6 +75,7 @@ joinable!(tasks -> projects (project_id));
 joinable!(tasks -> users (user_id));
 
 allow_tables_to_appear_in_same_query!(
+    holidays,
     memos,
     milestones,
     projects,


### PR DESCRIPTION
祝日をWBSのプロジェクト情報として返却する
※祝日の設定に関しては管理者が行うものとし、プロジェクト個別の管理やユーザー画面からの追加は行わない

現状は`/graphiql`から実施のこと